### PR TITLE
Add detection for Sequoia problems with shortcuts

### DIFF
--- a/Sources/ShortcutRecorder/SRRecorderControl.m
+++ b/Sources/ShortcutRecorder/SRRecorderControl.m
@@ -891,6 +891,18 @@ static void *_SRStyleGuideObservingContext = &_SRStyleGuideObservingContext;
     return allowModifierFlags;
 }
 
+- (BOOL)isRunningOnSequoia
+{
+    if (@available(macOS 15.0, *))
+    {
+        return YES;
+    }
+    else
+    {
+        return NO;
+    }
+}
+
 - (BOOL)areModifierFlagsAllowed:(NSEventModifierFlags)aModifierFlags forKeyCode:(SRKeyCode)aKeyCode
 {
     aModifierFlags &= SRCocoaModifierFlagsMask;
@@ -913,7 +925,11 @@ static void *_SRStyleGuideObservingContext = &_SRStyleGuideObservingContext;
 #pragma clang diagnostic pop
 
     os_activity_initiate("-[SRRecorderControl areModifierFlagsAllowed:forKeyCode:]", OS_ACTIVITY_FLAG_IF_NONE_PRESENT, ^{
-        if ((aModifierFlags == 0 && !self.allowsEmptyModifierFlags) ||
+        if ([self isRunningOnSequoia] && ![SRShortcut sequoiaValidModifiers:aModifierFlags])
+        {
+            allowModifierFlags = NO;
+        }
+        else if ((aModifierFlags == 0 && !self.allowsEmptyModifierFlags) ||
             ((aModifierFlags & self.allowedModifierFlags) != aModifierFlags))
         {
             allowModifierFlags = DelegateShouldUnconditionallyAllowModifierFlags();

--- a/Sources/ShortcutRecorder/SRRecorderControl.m
+++ b/Sources/ShortcutRecorder/SRRecorderControl.m
@@ -64,6 +64,11 @@ static void *_SRStyleGuideObservingContext = &_SRStyleGuideObservingContext;
 
     // Controls intrinsic width of the label.
     NSLayoutConstraint *_labelWidthConstraint;
+    
+    // We dont want to show the alert every time if the modifiers
+    // are not compatible with Sequoia, so track if this instance of
+    // the control has shown it already
+    BOOL _hasSequoiaAlertBeenShown;
 }
 
 - (instancetype)initWithFrame:(NSRect)aFrameRect
@@ -91,6 +96,7 @@ static void *_SRStyleGuideObservingContext = &_SRStyleGuideObservingContext;
     _cancelButtonToolTipTag = NSIntegerMax;
     _clearButtonToolTipTag = NSIntegerMax;
     _pausesGlobalShortcutMonitorWhileRecording = YES;
+    _hasSequoiaAlertBeenShown = NO;
 
     _notifyStyle = [NSInvocation invocationWithMethodSignature:[SRRecorderControlStyle instanceMethodSignatureForSelector:@selector(recorderControlAppearanceDidChange:)]];
     _notifyStyle.selector = @selector(recorderControlAppearanceDidChange:);
@@ -944,6 +950,17 @@ static void *_SRStyleGuideObservingContext = &_SRStyleGuideObservingContext;
     NSBeep();
 }
 
+- (void)showSequoiaAlert
+{
+    NSAlert *sequoiaAlert = [[NSAlert alloc] init];
+    
+    [sequoiaAlert setMessageText:SRLoc(@"Shortcut not valid")];
+    [sequoiaAlert setInformativeText:SRLoc(@"Shortcuts must include the command or control key. Shortcuts with only option or shift are not allowed by macOS.")];
+    [sequoiaAlert beginSheetModalForWindow:[self window] completionHandler:^(NSModalResponse returnCode) {
+        self->_hasSequoiaAlertBeenShown = YES;
+    }];
+}
+
 - (void)propagateValue:(id)aValue forBinding:(NSString *)aBinding
 {
     NSParameterAssert(aBinding != nil);
@@ -1061,7 +1078,12 @@ static void *_SRStyleGuideObservingContext = &_SRStyleGuideObservingContext;
 #pragma clang diagnostic pop
 
     os_activity_initiate("-[SRRecorderControl canEndRecordingWithObjectValue:]", OS_ACTIVITY_FLAG_DEFAULT, ^{
-        if ([self areModifierFlagsValid:aShortcut.modifierFlags forKeyCode:aShortcut.keyCode])
+        if ([self isRunningOnSequoia] && ![SRShortcut sequoiaValidModifiers:aShortcut.modifierFlags])
+        {
+            os_log_debug(OS_LOG_DEFAULT, "Modifiers %lu rejected on Sequoia", aShortcut.modifierFlags);
+            result = NO;
+        }
+        else if ([self areModifierFlagsValid:aShortcut.modifierFlags forKeyCode:aShortcut.keyCode])
         {
             if (DelegateCanRecordShortcut(aShortcut))
             {
@@ -1782,6 +1804,9 @@ static void *_SRStyleGuideObservingContext = &_SRStyleGuideObservingContext;
                 {
                     // Do not end editing and allow the client to make another attempt.
                     [self playAlert];
+
+                    if ([self isRunningOnSequoia] && ![newObjectValue isValidOnSequoia] && !_hasSequoiaAlertBeenShown)
+                        [self showSequoiaAlert];
                 }
 
                 result = YES;

--- a/Sources/ShortcutRecorder/SRShortcut.m
+++ b/Sources/ShortcutRecorder/SRShortcut.m
@@ -203,6 +203,15 @@ SRShortcutKey const SRShortcutKeyCharactersIgnoringModifiers = @"charactersIgnor
     return self;
 }
 
+#pragma mark Non-initializer class methods
+
++ (BOOL)sequoiaValidModifiers:(NSEventModifierFlags)modifierFlags
+{
+    BOOL noModifiers = (modifierFlags == 0);
+    BOOL hasCtrlOrCommand = (modifierFlags & (NSEventModifierFlagControl|NSEventModifierFlagCommand));
+    
+    return noModifiers || hasCtrlOrCommand;
+}
 
 #pragma mark Properties
 
@@ -222,6 +231,13 @@ SRShortcutKey const SRShortcutKeyCharactersIgnoringModifiers = @"charactersIgnor
     return d;
 }
 
+// A shortcut is invalid on Sequoia if it contains ONLY shift or option modifiers.
+// no modifiers is fine, but if any modifer is present, it must contain cmd and/or ctrl
+// https://developer.apple.com/forums/thread/763878?answerId=804374022#804374022
+- (BOOL) isValidOnSequoia
+{
+    return [[self class] sequoiaValidModifiers:self.modifierFlags];
+}
 
 #pragma mark Methods
 

--- a/Sources/ShortcutRecorder/include/ShortcutRecorder/SRShortcut.h
+++ b/Sources/ShortcutRecorder/include/ShortcutRecorder/SRShortcut.h
@@ -121,9 +121,20 @@ NS_SWIFT_NAME(Shortcut)
 - (instancetype)init NS_UNAVAILABLE;
 
 /*!
+ A convenient way to ask if the shortcut modifiers are valid on Sequoia without creating a shortcut
+ @seealso SRShortcut/isValidOnSequoia
+ */
++ (BOOL)sequoiaValidModifiers:(NSEventModifierFlags)modifierFlags;
+
+/*!
  A key code such as 0 ('a').
  */
 @property (readonly) SRKeyCode keyCode;
+
+/*!
+ Does the shortcut contain modifiers other than shift and option?  Sequoia requires that.
+ */
+@property (readonly) BOOL isValidOnSequoia;
 
 /*!
  Modifier flags such as NSEventModifierFlagCommand | NSEventModifierFlagOption.


### PR DESCRIPTION
This PR adds extra checks in `SRShortcutControl` to detect a shortcut which won't work on Sequoia.

The first time a shortcut is attempted which won't work on Sequoia, an `NSAlert` is displayed (not yet copyedited or localised in this PR).  The alert won't be displayed again for the lifetime of the control, but the shortcut will continued to be denied as long as it doesn't qualify.

Have tried to match the code and documentation style of the existing component, but most of it's checks for validity are handled by setting flags or delegate callbacks so this is, by definition, a little different.